### PR TITLE
switch from List::AllUtils to List::Util

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,7 @@ Revision history for Map-Metro
  [New Features]
 
  [Requirements]
+ - switched from List::AllUtils to List::Util ( http://is.gd/lmu_cac_debacle )
 
  [Revision]
 

--- a/META.json
+++ b/META.json
@@ -102,7 +102,7 @@
             "IO::Interactive" : "0",
             "Kavorka" : "0",
             "Kavorka::TraitFor::Parameter::doc" : "0",
-            "List::AllUtils" : "0",
+            "List::Util" : "1.33",
             "List::Compare" : "0",
             "Module::Pluggable" : "0",
             "Moops" : "0",

--- a/dist.ini
+++ b/dist.ini
@@ -143,7 +143,7 @@ Graph = 0
 IO::Interactive = 0
 Kavorka = 0
 Kavorka::TraitFor::Parameter::doc = 0
-List::AllUtils = 0
+List::Util = 1.33
 List::Compare = 0
 Module::Pluggable = 0
 Moops = 0
@@ -179,7 +179,7 @@ Test::More = 0.96
 ; authordep IO::Interactive
 ; authordep Kavorka
 ; authordep Kavorka::TraitFor::Parameter::doc
-; authordep List::AllUtils
+; authordep List::Util = 1.33
 ; authordep List::Compare
 ; authordep Module::Pluggable
 ; authordep Moose

--- a/iller.yaml
+++ b/iller.yaml
@@ -16,7 +16,7 @@ prereqs:
      - IO::Interactive
      - Kavorka
      - Kavorka::TraitFor::Parameter::doc
-     - List::AllUtils
+     - List::Util: 1.33
      - List::Compare
      - Module::Pluggable
      - Moose

--- a/lib/Map/Metro.pm
+++ b/lib/Map/Metro.pm
@@ -12,7 +12,7 @@ package Map::Metro {
     use MooseX::AttributeShortcuts;
     use Types::Standard -types;
     use Types::Path::Tiny -types;
-    use List::AllUtils 'any';
+    use List::Util 1.33 'any';
 
     use Map::Metro::Graph;
 

--- a/lib/Map/Metro/Cmd/Lines.pm
+++ b/lib/Map/Metro/Cmd/Lines.pm
@@ -8,7 +8,7 @@ use warnings;
 class Map::Metro::Cmd::Lines extends Map::Metro::Cmd using Moose {
 
     use MooseX::App::Command;
-    use List::AllUtils 'all';
+    use List::Util 1.33 'all';
 
     parameter cityname => (
         is => 'rw',

--- a/lib/Map/Metro/Emitter.pm
+++ b/lib/Map/Metro/Emitter.pm
@@ -8,7 +8,7 @@ package Map::Metro::Emitter {
 
     use Moose;
     use Kavorka;
-    use List::AllUtils 'none';
+    use List::Util 1.33 'none';
     use Types::Standard -types;
     use Map::Metro::Hook;
 

--- a/lib/Map/Metro/Standard/Moops.pm
+++ b/lib/Map/Metro/Standard/Moops.pm
@@ -8,7 +8,7 @@ package #
     Map::Metro::Standard::Moops {
 
     use base 'Moops';
-    use List::AllUtils();
+    use List::Util 1.33 ();
     use Map::Metro::Types();
     use Eponymous::Hash();
     use List::Compare();
@@ -20,7 +20,7 @@ package #
         my %opts = @_;
 
         push @{ $opts{'imports'} ||= [] } => (
-            'List::AllUtils'    => [qw/any none sum uniq/],
+            'List::Util'        => [qw/any none sum/],
             'Eponymous::Hash'   => ['eh'],
             'String::Trim'      => ['trim'],
             'feature'           => [qw/:5.16/],


### PR DESCRIPTION
due to http://is.gd/lmu_cac_debacle, the perl #toolchain gang is switching the most up-CPAN-river dependencies on List::MoreUtils (and List::AllUtils, which is a wrapper for LMU) to List::Util as much as possible.

There was one use of uniq() (not in List::Util yet, although that is planned) that I removed, since it is not used anywhere here and is documented as part of the API.
